### PR TITLE
Correções para correto funcionamento com as versões "Wordpress 4.4.1"…

### DIFF
--- a/wpwcpagseguro/classes/wpwcmodalpagseguro.class.php
+++ b/wpwcpagseguro/classes/wpwcmodalpagseguro.class.php
@@ -59,7 +59,7 @@ class WP_WC_Modal_Pagseguro {
         $term_id = NULL;
         
         if(isset($name) && !empty($name)){
-            $term_id = $wpdb->get_var($wpdb->prepare("SELECT term_id FROM $wpdb->terms WHERE name LIKE '".trim($name)."'"));
+            $term_id = $wpdb->get_var($wpdb->prepare("SELECT term_id FROM $wpdb->terms WHERE name LIKE %s", trim($name)));
             return !empty($term_id) ? $term_id : NULL;
         }
         
@@ -79,7 +79,7 @@ class WP_WC_Modal_Pagseguro {
         $term_name = NULL;
         
         if(isset($key) && !empty($key)){
-            $term_name = $wpdb->get_var($wpdb->prepare("SELECT name FROM $wpdb->terms WHERE term_id = $key"));
+            $term_name = $wpdb->get_var($wpdb->prepare("SELECT name FROM $wpdb->terms WHERE term_id = %s", $key));
             return !empty($term_name) ? $term_name : NULL;
         }
         
@@ -94,8 +94,8 @@ class WP_WC_Modal_Pagseguro {
      */
     public function updateOrder($order_id, $term_id){
         global $wpdb;
-        $term_taxonomy_id = $wpdb->get_var($wpdb->prepare("SELECT term_taxonomy_id FROM $wpdb->term_taxonomy WHERE term_id = $term_id"));
-        $term_taxonomy_id_relation = $wpdb->get_var($wpdb->prepare("SELECT term_taxonomy_id FROM $wpdb->term_relationships WHERE object_id = $order_id"));
+        $term_taxonomy_id = $wpdb->get_var($wpdb->prepare("SELECT term_taxonomy_id FROM $wpdb->term_taxonomy WHERE term_id = %s", $term_id));
+        $term_taxonomy_id_relation = $wpdb->get_var($wpdb->prepare("SELECT term_taxonomy_id FROM $wpdb->term_relationships WHERE object_id = %s", $order_id));
         if($term_taxonomy_id == $term_taxonomy_id_relation){
             return false;
         }else{

--- a/wpwcpagseguro/wpwcpagseguro.php
+++ b/wpwcpagseguro/wpwcpagseguro.php
@@ -114,7 +114,7 @@ function init_wp_wc_pagseguro_gateway_function() {
 
             // Active logs.
             if ( 'yes' == $this->debug ) {
-                $this->log = $woocommerce->logger();
+                $this->log = new WC_Logger();
                 $this->createLogFile($this->returnPathLog());
                 PagSeguroConfig::activeLog($this->returnPathLog());
             }


### PR DESCRIPTION
… e "woocommerce 2.4.13"
1. Alteração do método $wpdb->prepare, que foi modificado na versão
   recente do Wordpress.
2. Substituído código "$woocommerce->logger()" por "new WC_Logger();" em
   atendimento à modificação realizada na versão recente do woocommerce

As correções descritas adiante foram executadas para que o plugin
funcione corretamente na versão 4.4.1 do Wordpress e versão 2.4.13 do
woocommerce.

Arquivo wpwcpagseguro.php

Onde estava:
$this->log = $woocommerce->logger();

Agora está:
$this->log = new WC_Logger();

Arquivo wpwcmodalpagseguro.class.php

1.

Onde estava:
$term_id = $wpdb->get_var($wpdb->prepare("SELECT term_id FROM
$wpdb->terms WHERE name LIKE '".trim($name)."'"));

Agora está:
$term_id = $wpdb->get_var($wpdb->prepare("SELECT term_id FROM
$wpdb->terms WHERE name LIKE %s", trim($name)));

2.

Onde estava:
$term_name = $wpdb->get_var($wpdb->prepare("SELECT name FROM
$wpdb->terms WHERE term_id = $key"));

Agora está:
$term_name = $wpdb->get_var($wpdb->prepare("SELECT name FROM
$wpdb->terms WHERE term_id = %s", $key));

3.

Onde estava:
$term_taxonomy_id = $wpdb->get_var($wpdb->prepare("SELECT
term_taxonomy_id FROM $wpdb->term_taxonomy WHERE term_id = $term_id"));

Agora está:
$term_taxonomy_id = $wpdb->get_var($wpdb->prepare("SELECT
term_taxonomy_id FROM $wpdb->term_taxonomy WHERE term_id = %s",
$term_id));

4.

Onde estava:
$term_taxonomy_id_relation = $wpdb->get_var($wpdb->prepare("SELECT
term_taxonomy_id FROM $wpdb->term_relationships WHERE object_id =
$order_id"));

Agora está:
$term_taxonomy_id_relation = $wpdb->get_var($wpdb->prepare("SELECT
term_taxonomy_id FROM $wpdb->term_relationships WHERE object_id = %s",
$order_id));
